### PR TITLE
Feature/hb services

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2015 Hope Bay Technologies, Inc. All right reserved.
+
 Copyright 2014 Eddy Hernandez
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/index.js
+++ b/index.js
@@ -100,8 +100,13 @@ ProxyKeystone = function(customOptions){
 
     // begin req.url transformation
     req.url = req.url.split(proxyUrl)[1]; // remove /proxy/
-    serviceParams = req.url.split('/')[0]; // grabs 'catalogItem,[region]'
-    req.url = req.url.split(serviceParams)[1]; // transform req.url
+    if (req.service) {
+      serviceParams = req.service;
+    }
+    else {
+      serviceParams = req.url.split('/')[0]; // grabs 'catalogItem,[region]'
+      req.url = req.url.split(serviceParams)[1]; // transform req.url
+    }
 
     serviceInfo = self.parseService(serviceParams);
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "contributors": [{
     "name": "Joe Chen",
-    "email": "joe.chen@hopebaytech.com",
+    "email": "joe.chen@hopebaytech.com"
   }],
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,17 +3,21 @@
   "version": "2.0.1",
   "description": "A proxy for OpenStack Keystone service catalog endpoints built on top of http-proxy.",
   "main": "index.js",
-  "homepage": "https://github.com/eddywashere/proxy-keystone",
-  "bugs": "https://github.com/eddywashere/proxy-keystone/issues",
+  "homepage": "https://github.com/Hopebaytech/proxy-keystone",
+  "bugs": "https://github.com/Hopebaytech/proxy-keystone/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eddywashere/proxy-keystone"
+    "url": "https://github.com/Hopebaytech/proxy-keystone"
   },
   "author": {
     "name": "Eddy Hernandez",
     "email": "edward.d.hernandez@gmail.com",
     "url": "http://eddywashere.com"
   },
+  "contributors": [{
+    "name": "Joe Chen",
+    "email": "joe.chen@hopebaytech.com",
+  }],
   "license": "MIT",
   "keywords": [
     "proxy",


### PR DESCRIPTION
As a proxy to HB services, middleware should get service name from req object, instead of parsing request url.
